### PR TITLE
batch send failure #31

### DIFF
--- a/src/ApnChannel.php
+++ b/src/ApnChannel.php
@@ -107,6 +107,10 @@ class ApnChannel
                             'error' => $response->getCode(),
                         ])
                     );
+                    
+                    //connection is useless so create a new connection
+                    $this->closeConnection();
+                    $this->openConnection();
                 }
             } catch (Exception $e) {
                 throw SendingFailed::create($e);


### PR DESCRIPTION
create a nwe connection if sending a message failed because apple ignores rest of tokens on that connection